### PR TITLE
[DEV/FIX] Home Page 구성 및 SideMenu 높이 이슈 해결

### DIFF
--- a/src/app/_component/HomePage/HomePageDesktop.tsx
+++ b/src/app/_component/HomePage/HomePageDesktop.tsx
@@ -1,10 +1,27 @@
+import Link from "next/link";
+
 const HomePageDesktop = () => {
     return(
         <div className="flex flex-col mt-[200px] mx-[100px]">
             <HomePageDesktopTitle isBlue={false} text={"안녕하세요"} />
             <HomePageDesktopTitle isBlue={true} text={"대학생 1인개발자"} />
             <HomePageDesktopTitle isBlue={false} text={"LR입니다."} />
+            <div className="h-[50px]" />
+            <HomePageDesktopNav path={"/blog"} text={"Blog"} />
+            <HomePageDesktopNav path={"/project"} text={"Project"} />
+            <HomePageDesktopNav path={"/solving"} text={"Problem Solving"} />
+            <HomePageDesktopNav path={"/about"} text={"About Me"} />
         </div>
+    );
+}
+
+const HomePageDesktopNav = ({path, text}: {path: string, text: string}) => {
+    return(
+        <Link href={path}>
+            <div className="ms-[10px] my-[5px] font-nanum-r text-xl text-primary-blog_black">
+                {text}
+            </div>
+        </Link>
     );
 }
 

--- a/src/app/_component/HomePage/HomePageDesktop.tsx
+++ b/src/app/_component/HomePage/HomePageDesktop.tsx
@@ -1,9 +1,20 @@
 const HomePageDesktop = () => {
     return(
-        <div>
-            Home Page
+        <div className="flex flex-col mt-[200px] mx-[100px]">
+            <HomePageDesktopTitle isBlue={false} text={"안녕하세요"} />
+            <HomePageDesktopTitle isBlue={true} text={"대학생 1인개발자"} />
+            <HomePageDesktopTitle isBlue={false} text={"LR입니다."} />
         </div>
     );
 }
+
+const HomePageDesktopTitle = ({isBlue, text}: {isBlue: boolean, text: string}) => {
+    const TITLE_STYLE_BLACK = "my-[5px] font-nanum-r text-7xl text-primary-blog_black";
+    const TITLE_STYLE_BLUE = "my-[5px] font-nanum-b text-7xl text-primary-blog_blue";
+    return(
+        <span className={isBlue ? TITLE_STYLE_BLUE : TITLE_STYLE_BLACK}>{text}</span>
+    )
+}
+
 
 export default HomePageDesktop;

--- a/src/app/_component/HomePage/HomePageDesktop.tsx
+++ b/src/app/_component/HomePage/HomePageDesktop.tsx
@@ -1,0 +1,9 @@
+const HomePageDesktop = () => {
+    return(
+        <div>
+            Home Page
+        </div>
+    );
+}
+
+export default HomePageDesktop;

--- a/src/app/_component/SideMenu/SideMenuDesktop.tsx
+++ b/src/app/_component/SideMenu/SideMenuDesktop.tsx
@@ -5,7 +5,7 @@ import {UrlData} from "@/utils/UrlData";
 
 const SideMenuDesktop = () => {
     return(
-        <div className="h-full w-[400px] flex flex-col justify-end bg-primary-blog_blue">
+        <div className="h-screen w-[400px] flex flex-col justify-end bg-primary-blog_blue">
             <SideMenuTitle />
             <SideMenuDivider />
             <SideMenuNav />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
+import HomePageDesktop from "@/app/_component/HomePage/HomePageDesktop";
+
 export default function Home() {
     return (
-        <main className="flex min-h-screen flex-col items-center justify-between p-24">
-            <div>
-                Contents
-            </div>
-        </main>
+        <div className="invisible lg:visible">
+            <HomePageDesktop/>
+        </div>
     );
 }


### PR DESCRIPTION
## Summary
Home Page를 구성하였습니다.
SideMenu의 높이 이슈를 해결하였습니다.

## Description
- `/`의 경로에서 렌더링할 Home Page를 구성하였습니다. Title 및 NAV로 구성되었으며, NAV의 경우는 `/blog`, `/project`, `/solving` 및 `/about`으로 이동하도록 지정해두었습니다.
- 추후 개선사항으로, 각 NAV 버튼에 마우스 Hover 시 애니메이션을 추가할 예정입니다.
- SideMenu의 높이를 `h-screen` 속성을 추가하여 Viewport Height로 지정되도록 하였습니다.