### PR TITLE
[DEV] Post URL 프리뷰 구현

### DIFF
--- a/src/app/[type]/[id]/page.tsx
+++ b/src/app/[type]/[id]/page.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from "react";
 import type { Metadata } from "next";
 import MDRender from "../_component/MDRender/MDRender";
 import Utterances from "../_component/Utterances/Utterances";
-import { getFBPostData } from "@/utils/FirebaseUtil";
+import { getFBPostData, SITE_URL } from "@/utils/FirebaseUtil";
 import { notFound } from "next/navigation";
 import PostDetailLoading from "./loading";
 
@@ -45,6 +45,7 @@ export async function generateMetadata({
         openGraph: {
             title: `${PostTitle} - Useful Blog`,
             description,
+            url: `${SITE_URL}/${type}/${id}`,
             type: "article",
             images: [
                 {

--- a/src/app/[type]/[id]/page.tsx
+++ b/src/app/[type]/[id]/page.tsx
@@ -18,17 +18,49 @@ export async function generateMetadata({
 
     if (result.RESULT_CODE !== 200) {
         return {
-            title: "Post Not Found - Useful Blog",
+            title: "Post Not Found",
         };
     }
 
     const { PostTitle, PostTag } = result.RESULT_DATA;
     const categoryName = getCategoryNameKo(type);
     const tagsString = PostTag && PostTag.length > 0 ? `. 태그: ${PostTag.join(", ")}` : "";
+    const description = `Useful의 ${categoryName} 포스팅: ${PostTitle}${tagsString}`;
+
+    // Determine dynamic OG image
+    let imageUrl = "/logo.png";
+    if (type === "solving") {
+        if (id.startsWith("boj")) {
+            imageUrl = "/api/getPostImage?postType=solving&postID=dummy&srcID=thumb_boj.png";
+        } else if (id.startsWith("programmers")) {
+            imageUrl = "/api/getPostImage?postType=solving&postID=dummy&srcID=thumb_programmers.png";
+        }
+    } else {
+        imageUrl = `/api/getPostImage?postType=${type}&postID=${id}&srcID=post.png`;
+    }
 
     return {
-        title: `${PostTitle} - Useful Blog`,
-        description: `Useful의 ${categoryName} 포스팅: ${PostTitle}${tagsString}`,
+        title: PostTitle,
+        description,
+        openGraph: {
+            title: `${PostTitle} - Useful Blog`,
+            description,
+            type: "article",
+            images: [
+                {
+                    url: imageUrl,
+                    width: 1200,
+                    height: 630,
+                    alt: PostTitle,
+                },
+            ],
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: `${PostTitle} - Useful Blog`,
+            description,
+            images: [imageUrl],
+        },
     };
 }
 

--- a/src/app/api/getPostImage/route.ts
+++ b/src/app/api/getPostImage/route.ts
@@ -77,7 +77,8 @@ export async function GET(req: NextRequest) {
 
         const response = await fetchWithTimeout(url);
         if (!response.ok) {
-            return new Response("Image not found", { status: response.status });
+            const siteUrl = process.env.URL_PUB || "https://dev-lr.com";
+            return NextResponse.redirect(`${siteUrl}/logo.png`, 307);
         }
 
         const arrayBuffer = await response.arrayBuffer();

--- a/src/app/api/getPostImage/route.ts
+++ b/src/app/api/getPostImage/route.ts
@@ -77,8 +77,8 @@ export async function GET(req: NextRequest) {
 
         const response = await fetchWithTimeout(url);
         if (!response.ok) {
-            const siteUrl = process.env.URL_PUB || "https://dev-lr.com";
-            return NextResponse.redirect(`${siteUrl}/logo.png`, 307);
+            const { origin } = new URL(req.url);
+            return NextResponse.redirect(`${origin}/logo.png`, 307);
         }
 
         const arrayBuffer = await response.arrayBuffer();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import SideMenu from "@/app/_component/SideMenu/SideMenu";
 import "./globals.css";
+import { SITE_URL } from "@/utils/FirebaseUtil";
 
 const nanumSquareL = localFont({
     src: "../fonts/NanumSquareL.otf",
@@ -29,10 +30,8 @@ const pretendardB = localFont({
     variable: "--font-pretendard-b-next",
 });
 
-const siteUrl = process.env.URL_PUB || "https://dev-lr.com";
-
 export const metadata: Metadata = {
-    metadataBase: new URL(siteUrl),
+    metadataBase: new URL(SITE_URL),
     title: {
         default: "Useful Blog",
         template: "%s - Useful Blog",
@@ -41,7 +40,7 @@ export const metadata: Metadata = {
     openGraph: {
         title: "Useful Blog",
         description: "1인개발자 Useful의 IT블로그",
-        url: siteUrl,
+        url: SITE_URL,
         siteName: "Useful Blog",
         locale: "ko_KR",
         type: "website",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,9 +29,37 @@ const pretendardB = localFont({
     variable: "--font-pretendard-b-next",
 });
 
+const siteUrl = process.env.URL_PUB || "https://dev-lr.com";
+
 export const metadata: Metadata = {
-    title: "Useful Blog",
+    metadataBase: new URL(siteUrl),
+    title: {
+        default: "Useful Blog",
+        template: "%s - Useful Blog",
+    },
     description: "1인개발자 Useful의 IT블로그",
+    openGraph: {
+        title: "Useful Blog",
+        description: "1인개발자 Useful의 IT블로그",
+        url: siteUrl,
+        siteName: "Useful Blog",
+        locale: "ko_KR",
+        type: "website",
+        images: [
+            {
+                url: "/logo.png",
+                width: 512,
+                height: 512,
+                alt: "Useful Blog Logo",
+            },
+        ],
+    },
+    twitter: {
+        card: "summary",
+        title: "Useful Blog",
+        description: "1인개발자 Useful의 IT블로그",
+        images: ["/logo.png"],
+    },
 };
 
 export default function RootLayout({

--- a/src/utils/FirebaseUtil.ts
+++ b/src/utils/FirebaseUtil.ts
@@ -84,6 +84,7 @@ export const getFBPostList = cache(async (postType: string) => {
 });
 
 export const CDN_BASE_URL = "https://cdn.jsdelivr.net/gh/yymin1022/Blog_LR_Data@master";
+export const SITE_URL = process.env.URL_PUB || "https://dev-lr.com";
 
 export async function fetchWithTimeout(resource: string, options: RequestInit & { timeout?: number } = {}) {
     const { timeout = 8000 } = options;


### PR DESCRIPTION
## Summary
포스팅 링크 프리뷰에 Open Graph/Twitter Card 동적 메타데이터 구현

## Description
- layout.tsx에 metadataBase 및 기본 OG/Twitter 카드 메타데이터 설정을 추가 정의하였습니다.
- page.tsx의 generateMetadata를 수정하여 포스트별 제목, 태그, 썸네일을 매핑하였습니다.
- getPostImage API에서 이미지 조회 실패 시 기본 로고(/logo.png)로 리다이렉트 처리하여 예외처리를 적용하였습니다.