### PR TITLE
[DEV] Posting 메타데이터 관련 Migration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,3 @@
-# Firebase Configuration
-FB_API_KEY=your-firebase-api-key
-FB_AUTH_DOMAIN=your-firebase-auth-domain
-FB_PROJECT_ID=your-firebase-project-id
-FB_APP_ID=your-firebase-app-id
-
 # Local File System Path for Posts (e.g., /Users/yong/Projects/Web/Blog_LR_Data)
 POST_DATA_DIR=/path/to/Blog_LR_Data
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "firebase": "^10.12.0",
     "next": "16.2.6",
     "react": "19.2.6",
     "react-dom": "19.2.6",

--- a/src/app/[type]/[id]/page.tsx
+++ b/src/app/[type]/[id]/page.tsx
@@ -2,7 +2,7 @@ import React, { Suspense } from "react";
 import type { Metadata } from "next";
 import MDRender from "../_component/MDRender/MDRender";
 import Utterances from "../_component/Utterances/Utterances";
-import { getFBPostData, SITE_URL } from "@/utils/FirebaseUtil";
+import { getPostData, SITE_URL } from "@/utils/PostDataUtil";
 import { notFound } from "next/navigation";
 import PostDetailLoading from "./loading";
 
@@ -14,7 +14,8 @@ export async function generateMetadata({
     params: Promise<{ type: string; id: string }>;
 }): Promise<Metadata> {
     const { type, id } = await params;
-    const result = await getFBPostData(type, id);
+    const result = await getPostData(type, id);
+
 
     if (result.RESULT_CODE !== 200) {
         return {
@@ -80,7 +81,7 @@ export default async function PostViewPage({
 }
 
 async function PostViewContent({ type, id }: { type: string; id: string }) {
-    const result = await getFBPostData(type, id);
+    const result = await getPostData(type, id);
 
     if (result.RESULT_CODE !== 200) {
         notFound();

--- a/src/app/[type]/[id]/page.tsx
+++ b/src/app/[type]/[id]/page.tsx
@@ -23,7 +23,7 @@ export async function generateMetadata({
         };
     }
 
-    const { PostTitle, PostTag } = result.RESULT_DATA;
+    const { PostTitle, PostTag, PostURL } = result.RESULT_DATA;
     const categoryName = getCategoryNameKo(type);
     const tagsString = PostTag && PostTag.length > 0 ? `. 태그: ${PostTag.join(", ")}` : "";
     const description = `Useful의 ${categoryName} 포스팅: ${PostTitle}${tagsString}`;
@@ -37,7 +37,8 @@ export async function generateMetadata({
             imageUrl = "/api/getPostImage?postType=solving&postID=dummy&srcID=thumb_programmers.png";
         }
     } else {
-        imageUrl = `/api/getPostImage?postType=${type}&postID=${id}&srcID=post.png`;
+        const imageFolder = type === "about" ? id : PostURL;
+        imageUrl = `/api/getPostImage?postType=${type}&postID=${imageFolder}&srcID=post.png`;
     }
 
     return {

--- a/src/app/[type]/_component/PostCard/PostCard.tsx
+++ b/src/app/[type]/_component/PostCard/PostCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import PostCardDesktop from "@/app/[type]/_component/PostCard/PostCardDesktop";
-import { PostData } from "@/utils/FirebaseUtil";
+import { PostData } from "@/utils/PostDataUtil";
 
 interface PostCardProps {
     post: PostData;

--- a/src/app/[type]/_component/PostCard/PostCardDesktop.tsx
+++ b/src/app/[type]/_component/PostCard/PostCardDesktop.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "next/link";
-import { PostData } from "@/utils/FirebaseUtil";
+import { PostData } from "@/utils/PostDataUtil";
 
 interface PostCardDesktopProps {
     post: PostData;

--- a/src/app/[type]/page.tsx
+++ b/src/app/[type]/page.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from "react";
 import type { Metadata } from "next";
 import PostCard from "@/app/[type]/_component/PostCard/PostCard";
-import { getFBPostList, PostData } from "@/utils/FirebaseUtil";
+import { getPostList, PostData } from "@/utils/PostDataUtil";
 import { redirect } from "next/navigation";
 import PostListLoading from "./loading";
 
@@ -38,7 +38,7 @@ export default async function PostListPage({
 }
 
 async function PostListContent({ type }: { type: string }) {
-    const result = await getFBPostList(type);
+    const result = await getPostList(type);
     const postList: PostData[] = result.RESULT_CODE === 200 ? result.RESULT_DATA.PostList : [];
 
     const pinnedPosts = postList.filter((post) => post.postIsPinned);

--- a/src/app/api/getPostData/route.ts
+++ b/src/app/api/getPostData/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getFBPostData } from "@/utils/FirebaseUtil";
+import { getPostData } from "@/utils/PostDataUtil";
 
 export async function POST(req: NextRequest) {
     try {
@@ -13,7 +13,7 @@ export async function POST(req: NextRequest) {
             });
         }
 
-        const result = await getFBPostData(postType, postID);
+        const result = await getPostData(postType, postID);
         return NextResponse.json(result);
     } catch (error: any) {
         return NextResponse.json({

--- a/src/app/api/getPostData/route.ts
+++ b/src/app/api/getPostData/route.ts
@@ -1,15 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getPostData } from "@/utils/PostDataUtil";
 
+function isSafeInput(input: string | null): boolean {
+    if (!input) return false;
+    if (input.includes("/") || input.includes("\\") || input.includes("..")) {
+        return false;
+    }
+    return true;
+}
+
 export async function POST(req: NextRequest) {
     try {
         const body = await req.json();
         const { postID, postType } = body;
 
-        if (!postID || !postType) {
+        if (typeof postID !== "string" || typeof postType !== "string") {
             return NextResponse.json({
                 RESULT_CODE: 100,
-                RESULT_MSG: "Missing parameters"
+                RESULT_MSG: "Invalid parameters"
+            });
+        }
+
+        if (!isSafeInput(postID) || !isSafeInput(postType)) {
+            return NextResponse.json({
+                RESULT_CODE: 100,
+                RESULT_MSG: "Invalid parameters"
             });
         }
 

--- a/src/app/api/getPostImage/route.ts
+++ b/src/app/api/getPostImage/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getFBPostImage, fetchWithTimeout, CDN_BASE_URL } from "@/utils/FirebaseUtil";
+import { getPostImage, fetchWithTimeout, CDN_BASE_URL } from "@/utils/PostDataUtil";
 import path from "path";
 
 function isSafeInput(input: string | null): boolean {
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
             });
         }
 
-        const result = await getFBPostImage(postType, postID, srcID);
+        const result = await getPostImage(postType, postID, srcID);
         return NextResponse.json(result);
     } catch (error: any) {
         return NextResponse.json({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import SideMenu from "@/app/_component/SideMenu/SideMenu";
 import "./globals.css";
-import { SITE_URL } from "@/utils/FirebaseUtil";
+import { SITE_URL } from "@/utils/PostDataUtil";
 
 const nanumSquareL = localFont({
     src: "../fonts/NanumSquareL.otf",

--- a/src/utils/PostDataUtil.ts
+++ b/src/utils/PostDataUtil.ts
@@ -18,6 +18,16 @@ function isSafeInput(input: string | null): boolean {
     return true;
 }
 
+function stripFrontMatter(content: string): string {
+    if (content.startsWith("---")) {
+        const nextSeparatorIdx = content.indexOf("---", 3);
+        if (nextSeparatorIdx !== -1) {
+            return content.slice(nextSeparatorIdx + 3).trimStart();
+        }
+    }
+    return content;
+}
+
 export const CDN_BASE_URL = "https://cdn.jsdelivr.net/gh/yymin1022/Blog_LR_Data@master";
 export const SITE_URL = process.env.URL_PUB || "https://dev-lr.com";
 
@@ -136,7 +146,8 @@ export const getPostData = cache(async (postType: string, postID: string) => {
             throw new Error(`Failed to fetch post content (HTTP ${response.status})`);
         }
 
-        resultData.RESULT_DATA.PostContent = await response.text();
+        const rawContent = await response.text();
+        resultData.RESULT_DATA.PostContent = stripFrontMatter(rawContent);
         resultData.RESULT_CODE = 200;
         resultData.RESULT_MSG = "Success";
     } catch (error: any) {

--- a/src/utils/PostDataUtil.ts
+++ b/src/utils/PostDataUtil.ts
@@ -1,25 +1,5 @@
-import { FirebaseApp, getApp, getApps, initializeApp } from "firebase/app";
-import { collection, doc, Firestore, getDoc, getDocs, getFirestore, orderBy, query } from "firebase/firestore";
 import path from "path";
 import { cache } from "react";
-
-const firebaseConfig = {
-    apiKey: process.env.FB_API_KEY,
-    authDomain: process.env.FB_AUTH_DOMAIN,
-    projectId: process.env.FB_PROJECT_ID,
-    appId: process.env.FB_APP_ID
-};
-
-let firebaseApp: FirebaseApp;
-let firebaseDB: Firestore;
-
-export const initFB = (): Firestore => {
-    if (!firebaseApp) {
-        firebaseApp = getApps().length === 0 ? initializeApp(firebaseConfig) : getApp();
-        firebaseDB = getFirestore(firebaseApp);
-    }
-    return firebaseDB;
-};
 
 export interface PostData {
     postDate: string;
@@ -37,51 +17,6 @@ function isSafeInput(input: string | null): boolean {
     }
     return true;
 }
-
-export const getFBPostList = cache(async (postType: string) => {
-    const db = initFB();
-    const postList: PostData[] = [];
-    const resultData = {
-        RESULT_CODE: 0,
-        RESULT_MSG: "",
-        RESULT_DATA: {
-            PostCount: 0,
-            PostList: postList
-        }
-    };
-
-    if (!isSafeInput(postType)) {
-        resultData.RESULT_CODE = 100;
-        resultData.RESULT_MSG = "Invalid post type";
-        return resultData;
-    }
-
-    try {
-        const postCollectionList = await getDocs(
-            query(collection(db, postType), orderBy("isPinned", "desc"))
-        );
-        postCollectionList.forEach((curData) => {
-            resultData.RESULT_DATA.PostCount++;
-            const postData: PostData = {
-                postDate: curData.get("date") || "",
-                postID: curData.id,
-                postIsPinned: curData.get("isPinned") || false,
-                postTag: curData.get("tag") || [],
-                postTitle: curData.get("title") || "",
-                postURL: curData.get("url") || "",
-            };
-            resultData.RESULT_DATA.PostList.push(postData);
-        });
-
-        resultData.RESULT_CODE = 200;
-        resultData.RESULT_MSG = "Success";
-    } catch (error: any) {
-        resultData.RESULT_CODE = 100;
-        resultData.RESULT_MSG = error.message || String(error);
-    }
-
-    return resultData;
-});
 
 export const CDN_BASE_URL = "https://cdn.jsdelivr.net/gh/yymin1022/Blog_LR_Data@master";
 export const SITE_URL = process.env.URL_PUB || "https://dev-lr.com";
@@ -103,8 +38,52 @@ export async function fetchWithTimeout(resource: string, options: RequestInit & 
     }
 }
 
-export const getFBPostData = cache(async (postType: string, postID: string) => {
-    const db = initFB();
+// Fetch posts index mapping category slugs to PostData array
+const fetchPostsIndex = cache(async () => {
+    const url = `${CDN_BASE_URL}/posts.json`;
+    const response = await fetchWithTimeout(url, {
+        next: { revalidate: 60 } // Cache index for 60 seconds
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to fetch posts index (HTTP ${response.status})`);
+    }
+    return await response.json() as Record<string, PostData[]>;
+});
+
+export const getPostList = cache(async (postType: string) => {
+    const postList: PostData[] = [];
+    const resultData = {
+        RESULT_CODE: 0,
+        RESULT_MSG: "",
+        RESULT_DATA: {
+            PostCount: 0,
+            PostList: postList
+        }
+    };
+
+    if (!isSafeInput(postType)) {
+        resultData.RESULT_CODE = 100;
+        resultData.RESULT_MSG = "Invalid post type";
+        return resultData;
+    }
+
+    try {
+        const postsIndex = await fetchPostsIndex();
+        const categoryPosts = postsIndex[postType] || [];
+        
+        resultData.RESULT_DATA.PostList = categoryPosts;
+        resultData.RESULT_DATA.PostCount = categoryPosts.length;
+        resultData.RESULT_CODE = 200;
+        resultData.RESULT_MSG = "Success";
+    } catch (error: any) {
+        resultData.RESULT_CODE = 100;
+        resultData.RESULT_MSG = error.message || String(error);
+    }
+
+    return resultData;
+});
+
+export const getPostData = cache(async (postType: string, postID: string) => {
     const resultData = {
         RESULT_CODE: 0,
         RESULT_MSG: "",
@@ -125,18 +104,22 @@ export const getFBPostData = cache(async (postType: string, postID: string) => {
     }
 
     try {
-        const postDocData = await getDoc(doc(db, postType, postID));
-        if (!postDocData.exists()) {
+        const postsIndex = await fetchPostsIndex();
+        const categoryPosts = postsIndex[postType] || [];
+        const post = categoryPosts.find((p) => p.postID === postID);
+
+        if (!post) {
             resultData.RESULT_CODE = 100;
             resultData.RESULT_MSG = "Post not found";
             return resultData;
         }
-        resultData.RESULT_DATA.PostDate = postDocData.data().date || "";
-        resultData.RESULT_DATA.PostIsPinned = postDocData.data().isPinned || false;
-        resultData.RESULT_DATA.PostTag = postDocData.data().tag || [];
-        resultData.RESULT_DATA.PostTitle = postDocData.data().title || "";
 
-        const postURL = postDocData.data().url || "";
+        resultData.RESULT_DATA.PostDate = post.postDate || "";
+        resultData.RESULT_DATA.PostIsPinned = post.postIsPinned || false;
+        resultData.RESULT_DATA.PostTag = post.postTag || [];
+        resultData.RESULT_DATA.PostTitle = post.postTitle || "";
+        
+        const postURL = post.postURL || "";
         resultData.RESULT_DATA.PostURL = postURL;
 
         if (!isSafeInput(postURL)) {
@@ -145,14 +128,15 @@ export const getFBPostData = cache(async (postType: string, postID: string) => {
             return resultData;
         }
 
-        const url = `${CDN_BASE_URL}/${postType}/${postURL}/post.md`;
+        // For 'about' posts, the folder name matches the postID
+        const folderName = postType === "about" ? postID : postURL;
+        const url = `${CDN_BASE_URL}/${postType}/${folderName}/post.md`;
         const response = await fetchWithTimeout(url);
         if (!response.ok) {
             throw new Error(`Failed to fetch post content (HTTP ${response.status})`);
         }
 
         resultData.RESULT_DATA.PostContent = await response.text();
-
         resultData.RESULT_CODE = 200;
         resultData.RESULT_MSG = "Success";
     } catch (error: any) {
@@ -163,7 +147,7 @@ export const getFBPostData = cache(async (postType: string, postID: string) => {
     return resultData;
 });
 
-export const getFBPostImage = async (postType: string, postID: string, srcID: string) => {
+export const getPostImage = async (postType: string, postID: string, srcID: string) => {
     const resultData = {
         RESULT_CODE: 0,
         RESULT_MSG: "",

--- a/src/utils/PostDataUtil.ts
+++ b/src/utils/PostDataUtil.ts
@@ -57,7 +57,11 @@ const fetchPostsIndex = cache(async () => {
     if (!response.ok) {
         throw new Error(`Failed to fetch posts index (HTTP ${response.status})`);
     }
-    return await response.json() as Record<string, PostData[]>;
+    const data = await response.json();
+    if (!data || typeof data !== "object" || Array.isArray(data)) {
+        throw new Error("Invalid posts index structure: expected a JSON object");
+    }
+    return data as Record<string, PostData[]>;
 });
 
 export const getPostList = cache(async (postType: string) => {
@@ -79,7 +83,7 @@ export const getPostList = cache(async (postType: string) => {
 
     try {
         const postsIndex = await fetchPostsIndex();
-        const categoryPosts = postsIndex[postType] || [];
+        const categoryPosts = postsIndex && Array.isArray(postsIndex[postType]) ? postsIndex[postType] : [];
         
         resultData.RESULT_DATA.PostList = categoryPosts;
         resultData.RESULT_DATA.PostCount = categoryPosts.length;
@@ -115,7 +119,7 @@ export const getPostData = cache(async (postType: string, postID: string) => {
 
     try {
         const postsIndex = await fetchPostsIndex();
-        const categoryPosts = postsIndex[postType] || [];
+        const categoryPosts = postsIndex && Array.isArray(postsIndex[postType]) ? postsIndex[postType] : [];
         const post = categoryPosts.find((p) => p.postID === postID);
 
         if (!post) {


### PR DESCRIPTION
## Summary
Posting 관련 로직을 Markdown Metadata 기반으로 전환

## Description
- `FirebaseUtil.ts`를 `PostDataUtil.ts`로 변경하고, Firestore SDK 대신 CDN의 `posts.json` 인덱스를 패치하여 목록 및 본문 메타데이터를 조회하도록 구현하였습니다.
- layout.tsx, page.tsx 및 API 라우트(/api/getPostData, /api/getPostImage) 등의 임포트 및 서빙 로직을 `PostDataUtil` 구조와 신규 함수명(`getPostList`, `getPostData`, `getPostImage`)에 맞춰 리팩토링하였습니다.
- package.json에서 사용하지 않게 된 `firebase` 패키지 의존성을 완전히 제거하고, .env.example 내 Firebase 설정 변수들을 정리하여 프로젝트 구조를 경량화하였습니다.