### PR TITLE
[FIX] Sitemap 생성 Rule

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -8,11 +8,27 @@ interface PostIndexItem {
     postDate?: string;
 }
 
-function parsePostDate(dateStr?: string): Date {
-    if (!dateStr) return new Date();
+function parsePostDate(dateStr?: string): Date | undefined {
+    if (!dateStr) return undefined;
+
+    // solving 카테고리 문제 번호("BOJ 32932", "Programmers 12906") 및 임의 텍스트 필터링
+    if (/^(boj|programmers)/i.test(dateStr.trim())) {
+        return undefined;
+    }
+
     const cleaned = dateStr.replace(/\./g, ",");
     const parsed = new Date(cleaned);
-    return isNaN(parsed.getTime()) ? new Date() : parsed;
+    const time = parsed.getTime();
+
+    if (isNaN(time)) return undefined;
+
+    // 정상적인 연도 범위 (2000년 ~ 2100년) 외의 날짜는 제외
+    const year = parsed.getFullYear();
+    if (year < 2000 || year > 2100) {
+        return undefined;
+    }
+
+    return parsed;
 }
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
@@ -63,9 +79,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
                     .filter((post) => Boolean(post.postID))
                     .map((post) => {
                         const isAbout = category === "about";
+                        const postDate = parsePostDate(post.postDate);
+
                         return {
                             url: `${siteUrl}/${category}/${post.postID}`,
-                            lastModified: parsePostDate(post.postDate),
+                            ...(postDate ? { lastModified: postDate } : {}),
                             changeFrequency: isAbout ? ("monthly" as const) : ("weekly" as const),
                             priority: isAbout ? 0.7 : 0.6,
                         };


### PR DESCRIPTION
## Summary
Sitemap 생성 Rule을 변경합니다.

## Description
- 기존 #36 에서 작성한 Sitemap 생성 script에서는 `posts.json`을 기반으로 Date 정보를 작성합니다.
- 그러나, `solving` tag의 posting들은 Date 정보가 유효하지 않으므로, 올바르지 않은 `sitemap.xml`이 생성되지 않는 문제가 있습니다.
- 따라서, rule을 변경하여 유효하지 않은 Date 정보인 경우, `lastmod` 속성을 작성하지 않도록 변경합니다.